### PR TITLE
Bring-your-own triples example .py added to the first_steps folder. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+#VSCode files 
+.vscode/
+
 # Distribution / packaging
 .Python
 build/

--- a/docs/source/byo/data.rst
+++ b/docs/source/byo/data.rst
@@ -114,7 +114,9 @@ desired behavior as in:
 >>> result.save_to_directory('doctests/test_pre_stratified_transe')
 
 Triples factories can also be instantiated using the ``triples`` keyword argument instead of the ``path`` argument
-if you already have triples loaded in a :class:`numpy.ndarray`.
+if you already have triples loaded in a :class:`numpy.ndarray`:
+
+>>> TriplesFactory.from_labeled_triples(triples=ndarray_of_triples)
 
 Unstratified Dataset
 --------------------

--- a/docs/source/byo/data.rst
+++ b/docs/source/byo/data.rst
@@ -116,7 +116,7 @@ desired behavior as in:
 Triples factories can also be instantiated using the ``triples`` keyword argument instead of the ``path`` argument
 if you already have triples loaded in a :class:`numpy.ndarray`:
 
->>> TriplesFactory.from_labeled_triples(triples=ndarray_of_triples)
+>>> tf = TriplesFactory.from_labeled_triples(triples=ndarray_of_triples)
 
 Unstratified Dataset
 --------------------

--- a/docs/source/examples/first_steps/bring_your_own_data.py
+++ b/docs/source/examples/first_steps/bring_your_own_data.py
@@ -1,0 +1,49 @@
+import numpy as np
+from pykeen.datasets import Dataset
+from pykeen.pipeline import pipeline
+from pykeen.triples import TriplesFactory
+
+# Bring Your Own Triples
+# -------------------
+# It's unlikely that the data you want to work with is already in the PyKEEN package.
+# Moreso, you might want to train a model on triples you have already prepared.
+# This example demonstrates the most basic way to bring your own data to PyKEEN.
+
+# define a set of triples. In this case, we'll make up some data about the Beatles
+# The triples are in the form (head, relation, tail)
+# The triples should be a numpy array with shape (n, 3)
+beatles_triples = np.array([
+    ['Paul McCartney', 'member of', 'The Beatles'],
+    ['John Lennon', 'member of', 'The Beatles'],
+    ['George Harrison', 'member of', 'The Beatles'],
+    ['Ringo Starr', 'member of', 'The Beatles'],
+    ['The Beatles', 'genre', 'rock'],
+    ['The Beatles', 'genre', 'pop'],
+    ['The Beatles', 'genre', 'psychedelic rock'],
+    ['The Beatles', 'genre', 'art rock'],
+    ['The Ed Sullivan Show', 'hosted', 'The Beatles'],
+    ['The Beatles', 'formed', 'Liverpool'],
+    ['Paul McCartney', 'born in', 'Liverpool'],
+    ['John Lennon', 'born in', 'Liverpool'],
+    ['George Harrison', 'born in', 'Liverpool'],
+    ['Ringo Starr', 'born in', 'Liverpool'],
+])
+
+# instantiate a triples factory, using the from_labeled_triples class method
+beatles_triples_factory = TriplesFactory.from_labeled_triples(triples=beatles_triples)
+
+# after creating the triples factory, you can examine the triples
+
+# print(beatles_triples_factory.triples)
+
+# Just having the triples might be enough for your use case, if you're training a model directly.
+# However, the Dataset abstraction provides an easy way to work with triples in the pipeline.
+# instantiate a dataset
+beatles_dataset = Dataset.from_tf(beatles_triples_factory)
+
+# Now you can use your own triples in a PyKEEN pipeline.
+# For example, you could train a model using the TransE model in a pipeline.
+result = pipeline(
+    model='TransE',
+    dataset=beatles_dataset,
+)

--- a/docs/source/examples/first_steps/bring_your_own_data.py
+++ b/docs/source/examples/first_steps/bring_your_own_data.py
@@ -6,8 +6,9 @@ from pykeen.triples import TriplesFactory
 # Bring Your Own Triples
 # -------------------
 # It's unlikely that the data you want to work with is already in the PyKEEN package.
-# Moreso, you might want to train a model on triples you have already prepared.
+# YOu most likely want to train a model on triples you have already prepared.
 # This example demonstrates the most basic way to bring your own data to PyKEEN.
+# If you have triples that already have relation & entity mappings, you can use the TriplesFactory class constructor directly - that is not shown here.
 
 # define a set of triples. In this case, we'll make up some data about the Beatles
 # The triples are in the form (head, relation, tail)

--- a/docs/source/examples/first_steps/bring_your_own_triples.py
+++ b/docs/source/examples/first_steps/bring_your_own_triples.py
@@ -9,6 +9,7 @@ from pykeen.triples import TriplesFactory
 # YOu most likely want to train a model on triples you have already prepared.
 # This example demonstrates the most basic way to bring your own data to PyKEEN.
 # If you have triples that already have relation & entity mappings, you can use the TriplesFactory class constructor directly - that is not shown here.
+# For a complete deep dive into Bringing Your Own Data to PyKeen, see https://pykeen.readthedocs.io/en/stable/byo/data.html
 
 # define a set of triples. In this case, we'll make up some data about the Beatles
 # The triples are in the form (head, relation, tail)


### PR DESCRIPTION
*Why is this required*

Many of the examples skip the data loading stage by using the built-in datasets. This leaves a hole in the Quick Start knowledge that we can easily fill. This knowledge is contained in the docs disparately spread across the BYO .rst's, but could be centralized in an example.

*What is the change* 
This PR adds a file to the `first_steps` folder in `examples`, `bring_your_own_data.py`. In this file, I cover how to hydrate a dataset & ultimately run a pipeline using triples loaded from a 2d array. 
There is no new functionality added to the library itself.

I added an explicit example to the .rst for BYO data as well, since it was missing. just a tiny change, thought it helps.

Finally, I also added a small change to the gitignore - I work in VSCode, and this will make life easier for future contributors to avoid accidentally committing settings & workspace files.

*Validation steps* 
I have executed the example, and kept is well-annotated and minimal as possible to reduce the chance of exceptions. As of now, it runs fine. 

